### PR TITLE
Needs GHC >= 7.8

### DIFF
--- a/control-monad-free.cabal
+++ b/control-monad-free.cabal
@@ -25,7 +25,7 @@ source-repository head
 
 Library
   buildable: True
-  build-depends: base >= 2 && < 5, transformers, prelude-extras
+  build-depends: base >= 4.7 && < 5, transformers, prelude-extras
   extensions:  StandaloneDeriving, Rank2Types, MultiParamTypeClasses, FlexibleInstances, FlexibleContexts, UndecidableInstances, OverlappingInstances
   exposed-modules:
      Control.Monad.Free


### PR DESCRIPTION
Build matrix: http://matrix.hackage.haskell.org/package/control-monad-free#GHC-7.4/control-monad-free-0.6.1

I've revised the existing version, http://hackage.haskell.org/package/control-monad-free/revisions/

