### PR TITLE
Remove >= from Cabal-Version

### DIFF
--- a/control-monad-free.cabal
+++ b/control-monad-free.cabal
@@ -1,6 +1,6 @@
 name: control-monad-free
 version: 0.6.2
-Cabal-Version:  >= 1.24
+Cabal-Version: 1.24
 build-type: Simple
 license: PublicDomain
 author: Luke Palmer, Pepe Iborra


### PR DESCRIPTION
Hopefully this suppresses the following warning:

```
Warning: control-monad-free.cabal:3:24: Packages with 'cabal-version: 1.12' or
later should specify a specific version of the Cabal spec of the form
'cabal-version: x.y'. Use 'cabal-version: 1.24'.
```